### PR TITLE
Fix: target info 頁面沒有正常顯示目標詳細資訊

### DIFF
--- a/frontend/apis/targets.tsx
+++ b/frontend/apis/targets.tsx
@@ -1,6 +1,6 @@
 import { Target } from "../models/targets";
 
-export async function fetchTargets(targetId?: number): Promise<Target[]> {
+export async function fetchTargets(targetId?: number): Promise<Target> {
   try {
     let url = `${process.env.NEXT_PUBLIC_API_URL}/api/targets/`;
 
@@ -16,10 +16,6 @@ export async function fetchTargets(targetId?: number): Promise<Target[]> {
       },
       credentials: "include",
     });
-
-    if (!response.ok) {
-      return [];
-    }
 
     const data = await response.json();
     return data;

--- a/frontend/apis/targets.tsx
+++ b/frontend/apis/targets.tsx
@@ -1,24 +1,17 @@
 import { Target } from "../models/targets";
+import api from "./wrapper";
 
 export async function fetchTargets(targetId?: number): Promise<Target[]> {
   try {
-    let url = `${process.env.NEXT_PUBLIC_API_URL}/api/targets/`;
+    let url = "/api/targets/";
 
     // Append query parameter if targetId is provided
     if (targetId) {
       url += `?target_id=${encodeURIComponent(targetId)}`;
     }
 
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-    });
-
-    const data = await response.json();
-    return data;
+    const response = await api.get(url);
+    return response.data;
   } catch (error) {
     console.error(error);
     throw error;
@@ -27,158 +20,75 @@ export async function fetchTargets(targetId?: number): Promise<Target[]> {
 
 export async function createTarget(newTarget: Target) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(newTarget),
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    return response;
+    const response = await api.post("/api/targets/", newTarget);
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function bulkCreate(file: FormData) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/bulk/`,
-      {
-        method: "POST",
-        body: file,
-        credentials: "include",
-      }
-    )
-      .then((response) => response.json())
-      .then((data) => {
-        console.log("File uploaded successfully:", data);
-        // Handle success, e.g., show a success message
-      })
-      .catch((error) => {
-        console.error("Error uploading file:", error);
-        // Handle error, e.g., show an error message
-      });
+    const response = await api.post("/api/targets/bulk/", file);
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function deleteTarget(id: number) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/${id}/delete/`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    const deletedTarget = await response.json();
-    return deletedTarget;
+    const response = await api.post(`/api/targets/${id}/delete/`, {});
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function deleteBulkTarget(target_ids: number[]) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/delete/bulk/`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: JSON.stringify({ target_ids: target_ids }),
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    const deletedTarget = await response.json();
-    return deletedTarget;
+    const response = await api.post("/api/targets/bulk/delete/", {
+      target_ids: target_ids,
+    });
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function getMoonAltAz(start_time: string, end_time: string) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/getMoon/`,
-      {
-        method: "POST",
-        body: JSON.stringify({ start_time: start_time, end_time: end_time }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    const moonAltAz = await response.json();
-    return moonAltAz;
+    const response = await api.post("/api/targets/moon/altaz/", {
+      start_time: start_time,
+      end_time: end_time,
+    });
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function getTargetSimbad(target_id: number) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/${target_id}/simbad/`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    const targetSimbad = await response.json();
-    return targetSimbad;
+    const response = await api.get("/api/targets/" + target_id + "/simbad");
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }
 
 export async function getTargetSED(target_id: number) {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/api/targets/${target_id}/sed/`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        credentials: "include",
-      }
-    );
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    const targetSED = await response.json();
-    return targetSED;
+    const response = await api.get("/api/targets/" + target_id + "/sed/");
+    return response.data;
   } catch (error) {
+    console.error(error);
     throw error;
   }
 }

--- a/frontend/apis/targets.tsx
+++ b/frontend/apis/targets.tsx
@@ -24,7 +24,7 @@ export async function fetchTargets(targetId?: number): Promise<Target[]> {
     const data = await response.json();
     return data;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     throw error;
   }
 }

--- a/frontend/apis/targets.tsx
+++ b/frontend/apis/targets.tsx
@@ -1,6 +1,6 @@
 import { Target } from "../models/targets";
 
-export async function fetchTargets(targetId?: number): Promise<Target> {
+export async function fetchTargets(targetId?: number): Promise<Target[]> {
   try {
     let url = `${process.env.NEXT_PUBLIC_API_URL}/api/targets/`;
 

--- a/frontend/apis/wrapper.tsx
+++ b/frontend/apis/wrapper.tsx
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  withCredentials: true,
+});
+
+export default api;

--- a/frontend/app/(contents)/targets/[id]/aladin.tsx
+++ b/frontend/app/(contents)/targets/[id]/aladin.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useState } from "react";
 import Script from "next/script";
+import { useEffect, useState, Suspense } from "react";
 import { Target } from "@/models/targets";
-import { Suspense } from "react";
 
 export default function Aladin(props: { target?: Target | null }) {
   const [aladinInitialized, setAladinInitialized] = useState(false);

--- a/frontend/app/(contents)/targets/[id]/info.tsx
+++ b/frontend/app/(contents)/targets/[id]/info.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, Suspense } from "react";
 import { Target, TargetSimbad } from "@/models/targets";
 import { getTargetSimbad } from "@/apis/targets";
 import Divider from "@mui/material/Divider";
@@ -74,9 +74,9 @@ export default function Info(props: Props) {
               Views
             </dt>
             <dd className="mt-1 text-sm leading-6 text-gray-300 sm:col-span-2 sm:mt-0">
-              <React.Suspense fallback={<div>Loading...</div>}>
+              <Suspense fallback={<div>Loading...</div>}>
                 <Aladin target={props.target} />
-              </React.Suspense>
+              </Suspense>
             </dd>
           </div>
           <div className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">

--- a/frontend/app/(contents)/targets/[id]/info.tsx
+++ b/frontend/app/(contents)/targets/[id]/info.tsx
@@ -1,10 +1,10 @@
+import { useEffect, useState } from "react";
 import { Target, TargetSimbad } from "@/models/targets";
-import Aladin from "./aladin";
-import Simbad from "./simbad";
 import { getTargetSimbad } from "@/apis/targets";
-import * as React from "react";
 import Divider from "@mui/material/Divider";
 import ScatterSED from "./scatterSED";
+import Aladin from "./aladin";
+import Simbad from "./simbad";
 
 type Props = {
   target?: Target | null;
@@ -17,10 +17,10 @@ declare global {
 }
 
 export default function Info(props: Props) {
-  const [targetSimbad, setTargetSimbad] = React.useState<TargetSimbad | null>();
-  const [isLoading, setIsLoading] = React.useState(true);
+  const [targetSimbad, setTargetSimbad] = useState<TargetSimbad | null>();
+  const [isLoading, setIsLoading] = useState(true);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (props.target && props.target.id) {
       getTargetSimbad(props.target.id)
         .then((targetSimbad) => {

--- a/frontend/app/(contents)/targets/[id]/page.tsx
+++ b/frontend/app/(contents)/targets/[id]/page.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useState, SyntheticEvent } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
 import { fetchTargets } from "@/apis/targets";
 import { Target } from "@/models/targets";
 import AdsClickOutlinedIcon from "@mui/icons-material/AdsClickOutlined";
@@ -7,42 +10,33 @@ import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import PersonPinIcon from "@mui/icons-material/PersonPin";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-import { useRouter } from "next/navigation";
 import PopDialog from "@/components/Dialog";
-import * as React from "react";
 import Info from "./info";
 import Detail from "./detail";
 import Observations from "./observations";
 
 export default function Page({ params }: { params: { id: number } }) {
-  const [value, setValue] = React.useState(0);
-  const [target, setTarget] = React.useState<Target | null>(null);
-
+  const [value, setValue] = useState(0);
   const router = useRouter();
 
-  React.useEffect(() => {
-    fetchTargets(params.id)
-      .then((data) => {
-        setTarget(data[0]);
-      })
-      .catch((error) => {
-        console.log(error);
-        router.push("/targets");
-      });
-  }, [params.id, router]);
+  const { data: targetData } = useQuery({
+    queryKey: ["getTarget"],
+    queryFn: () => fetchTargets(params.id),
+    initialData: {} as Target,
+  });
 
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleChange = (event: SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
 
   const renderTabContent = () => {
     switch (value) {
       case 0:
-        return <Info target={target} />;
+        return <Info target={targetData} />;
       case 1:
-        return <Observations target={target} />;
+        return <Observations target={targetData} />;
       case 2:
-        return <Detail target={target} />;
+        return <Detail target={targetData} />;
       default:
         return <div>Loading...</div>;
     }
@@ -53,9 +47,11 @@ export default function Page({ params }: { params: { id: number } }) {
       <PopDialog />
       <div className="mx-auto max-w-2xl lg:text-center">
         <p className="mt-2 text-5xl font-bold tracking-tight text-[#96fb4d] sm:text-5xl">
-          {target?.name}
+          {targetData?.name}
         </p>
-        <p className="mt-6 text-lg leading-8 text-gray-600">{target?.notes}</p>
+        <p className="mt-6 text-lg leading-8 text-gray-600">
+          {targetData?.notes}
+        </p>
       </div>
       <div className="mx-auto max-w-2xl lg:max-w-none flex items-center justify-center">
         <Tabs

--- a/frontend/app/(contents)/targets/[id]/page.tsx
+++ b/frontend/app/(contents)/targets/[id]/page.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import { useState, SyntheticEvent } from "react";
-import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
 import { fetchTargets } from "@/apis/targets";
+import PopDialog from "@/components/Dialog";
 import { Target } from "@/models/targets";
 import AdsClickOutlinedIcon from "@mui/icons-material/AdsClickOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import PersonPinIcon from "@mui/icons-material/PersonPin";
 import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
-import PopDialog from "@/components/Dialog";
-import Info from "./info";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { SyntheticEvent, useState } from "react";
 import Detail from "./detail";
+import Info from "./info";
 import Observations from "./observations";
 
 export default function Page({ params }: { params: { id: number } }) {
@@ -22,7 +22,7 @@ export default function Page({ params }: { params: { id: number } }) {
   const { data: targetData } = useQuery({
     queryKey: ["getTarget"],
     queryFn: () => fetchTargets(params.id),
-    initialData: {} as Target,
+    initialData: [] as Target[],
   });
 
   const handleChange = (event: SyntheticEvent, newValue: number) => {
@@ -32,11 +32,11 @@ export default function Page({ params }: { params: { id: number } }) {
   const renderTabContent = () => {
     switch (value) {
       case 0:
-        return <Info target={targetData} />;
+        return <Info target={targetData[0]} />;
       case 1:
-        return <Observations target={targetData} />;
+        return <Observations target={targetData[0]} />;
       case 2:
-        return <Detail target={targetData} />;
+        return <Detail target={targetData[0]} />;
       default:
         return <div>Loading...</div>;
     }
@@ -47,10 +47,10 @@ export default function Page({ params }: { params: { id: number } }) {
       <PopDialog />
       <div className="mx-auto max-w-2xl lg:text-center">
         <p className="mt-2 text-5xl font-bold tracking-tight text-[#96fb4d] sm:text-5xl">
-          {targetData?.name}
+          {targetData[0]?.name}
         </p>
         <p className="mt-6 text-lg leading-8 text-gray-600">
-          {targetData?.notes}
+          {targetData[0]?.notes}
         </p>
       </div>
       <div className="mx-auto max-w-2xl lg:max-w-none flex items-center justify-center">

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,9 +1,10 @@
+import type { Metadata } from "next";
+import Provider from "@/redux/provider";
+import { ReactQueryClientProvider } from "@/components/ReactQueryClientProvider";
+import { ThemeProvider } from "@/components/ui/theme-provider";
 import Background from "@/components/Background";
 import { NavBar } from "@/components/Navbar";
 import Setup from "@/components/setup";
-import Provider from "@/redux/provider";
-import { ThemeProvider } from "@/components/ui/theme-provider";
-import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -17,24 +18,26 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <main>
-            <Provider>
-              <Setup />
-              <NavBar />
-              <Background />
-              {children}
-            </Provider>
-          </main>
-        </ThemeProvider>
-      </body>
-    </html>
+    <ReactQueryClientProvider>
+      <html lang="en" suppressHydrationWarning>
+        <body>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <main>
+              <Provider>
+                <Setup />
+                <NavBar />
+                <Background />
+                {children}
+              </Provider>
+            </main>
+          </ThemeProvider>
+        </body>
+      </html>
+    </ReactQueryClientProvider>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,5 @@
-import Block from "@/components/Block";
 import Image from "next/image";
+import Block from "@/components/Block";
 import styles from "./page.module.css";
 
 export default function Home() {

--- a/frontend/components/ReactQueryClientProvider.tsx
+++ b/frontend/components/ReactQueryClientProvider.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export const ReactQueryClientProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
         "@reduxjs/toolkit": "^2.0.1",
+        "@tanstack/react-query": "^5.29.2",
         "@tanstack/react-table": "^8.14.0",
         "async-mutex": "^0.4.0",
         "axios": "^1.6.2",
@@ -2735,6 +2736,30 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.29.0.tgz",
+      "integrity": "sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
+      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.29.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
     "@reduxjs/toolkit": "^2.0.1",
+    "@tanstack/react-query": "^5.29.2",
     "@tanstack/react-table": "^8.14.0",
     "async-mutex": "^0.4.0",
     "axios": "^1.6.2",


### PR DESCRIPTION
- 一開始是想看一下 aladin 的錯誤，沒想到 target info 也跑不出來，所以就先修了這個 bug。
- 原本 target[id] page 是使用 useEffect 去跟 API 取資料然後用 state 存下來。為了更好的區隔前端 state 跟後端來的資料，引入了 react query 來管理從 API 進來的資料。
- 順便微調了一些檔案的 import 順序。雖然 `import * as React` 也不是不行，但一個頁面要用的 function 其實不會到很多，個人認為直接 `import { useState, useEffect } from 'react'` 會比較簡潔。
- 關於 target 那邊的資料型別，因為不太熟 typescript，雖然目前沒有 error，但可能還是會有改錯的地方。